### PR TITLE
Update REMOVE_ALL_MODULES to handle '<locals>'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0 (2024-03-08)
+
+- Changed `REMOVE_ALL_MODULES`'s regex pattern to also remove `<locals>` from rendered output. `<locals>` typically appears in a type's qualified name if the type was defined within the local scope of a function or class method. 
+
 ## v1.0.0 (2023-02-20)
 
 Initial release! 🎉

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ typenames(
 #> 'Optional[BaseNode]'
 ```
 
-To remove all module names, you can use `REMOVE_ALL_MODULES`, which contains the pattern `re.compile(r"^(\w+\.)+")`.
+To remove all module names, you can use `REMOVE_ALL_MODULES`, which contains the pattern `re.compile(r"^(<?\w+>?\.)+")`.
 
 ---
 

--- a/tests.py
+++ b/tests.py
@@ -125,32 +125,41 @@ def test_typenames(case):
 
 
 def test_remove_modules():
+    # Simulate a class from another module
     class OtherModuleClass:
         __qualname__ = "OtherModuleClass"
         __module__ = "other_module"
 
+    # Class defined in a function scope
+    class FnScopeClass: ...
+
+    # Default removal
     assert typenames(typing.Any) == "Any"
     assert typenames(MyClass) == "tests.MyClass"
     assert typenames(OtherModuleClass) == "other_module.OtherModuleClass"
+    assert typenames(FnScopeClass) == "tests.test_remove_modules.<locals>.FnScopeClass"
 
     # Override
     config = TypenamesConfig(remove_modules=["tests"])
     assert typenames(typing.Any, config=config) == "typing.Any"
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
+    assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
 
     # Add to defaults
     config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["tests"])
     assert typenames(typing.Any, config=config) == "Any"
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
+    assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
 
-    # All types
+    # All modules
     config = TypenamesConfig(remove_modules=REMOVE_ALL_MODULES)
     assert typenames(typing.Any, config=config) == "Any"
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "OtherModuleClass"
     assert typenames(OtherModuleClass, config=config) == "OtherModuleClass"
+    assert typenames(FnScopeClass, config=config) == "FnScopeClass"
 
     if sys.version_info >= (3, 9):
         assert typenames(collections.Counter[str], config=config) == "Counter[str]"

--- a/typenames.py
+++ b/typenames.py
@@ -65,7 +65,7 @@ DEFAULT_REMOVE_MODULES: List[Union[str, re.Pattern]] = [
 ]
 """List of standard library modules used as the default value for the remove_modules option."""
 
-REMOVE_ALL_MODULES = [re.compile(r"^(\w+\.)+")]
+REMOVE_ALL_MODULES = [re.compile(r"^(<?\w+>?\.)+")]
 
 
 @dataclasses.dataclass

--- a/typenames.py
+++ b/typenames.py
@@ -15,7 +15,7 @@ except ImportError:
     from typing_extensions import get_args, get_origin  # type: ignore # Python 3.7
 
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 OR_OPERATOR_SUPPORTED = sys.version_info >= (3, 10)
 """Flag for whether PEP 604's | operator (bitwise or) between types is supported."""


### PR DESCRIPTION
When defining a class inside a function or method, the qualified name of that class includes `<locals>`. This PR adds this case to the tests, and it updates the `REMOVE_ALL_MODULES` regex to remove it. 