### PR TITLE
Support PEP 561 typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.0 (2024-03-19)
+
+- Fixed the type signatures of `typenames` and `parse_type_tree` to reflect the typing of input type annotations, according to static type checkers.
+- Added [PEP 561 `py.typed` marker file](https://peps.python.org/pep-0561/#packaging-type-information) to indicate that the package supports type checking. 
+
 ## v1.1.0 (2024-03-08)
 
 - Changed `REMOVE_ALL_MODULES`'s regex pattern to also remove `<locals>` from rendered output. `<locals>` typically appears in a type's qualified name if the type was defined within the local scope of a function or class method. ([PR #4](https://github.com/jayqi/typenames/pull/4))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,26 +35,22 @@ tests = ["pytest>=6"]
 "Changelog" = "https://jayqi.github.io/typenames/stable/changelog/"
 
 [tool.hatch.version]
-path = "typenames.py"
-
-[tool.hatch.build]
-exclude = ["inspect_types/", "docs/", "mkdocs.yml"]
-
+path = "typenames/__init__.py"
 
 ## DEFAULT ENVIRONMENT ##
 
 [tool.hatch.envs.default]
-dependencies = ["black", "ipython", "mypy", "reprexlite", "ruff"]
+dependencies = ["ipython", "mypy", "reprexlite", "ruff"]
 python = "3.10"
 path = ".venv"
 
 [tool.hatch.envs.default.scripts]
+format = ["ruff format"]
 lint = [
-  "black --check typenames.py tests.py",
-  "ruff check typenames.py tests.py",
+  "ruff format --check",
+  "ruff check",
 ]
-typecheck = ["mypy typenames.py --install-types --non-interactive"]
-
+typecheck = ["mypy --install-types --non-interactive"]
 
 ## TESTS ENVIRONMENT ##
 
@@ -67,9 +63,8 @@ template = "tests"
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.tests.scripts]
-run = "pytest tests.py --cov=typenames --cov-report=term --cov-report=html --cov-report=xml"
+run = "pytest tests --cov=typenames --cov-report=term --cov-report=html --cov-report=xml"
 run-debug = "run --pdb"
-
 
 ## DOCS ENVIRONMENT ##
 
@@ -91,7 +86,6 @@ build = [
   "mkdocs build",
 ]
 
-
 ## INSPECT-TYPES ENVIRONMENT ##
 
 [tool.hatch.envs.inspect-types]
@@ -109,45 +103,30 @@ jupyter nbconvert inspect_types/_inspect_types.ipynb \
 --execute \
 --allow-errors"""
 
-
 ## TOOLS ##
-
-[tool.black]
-line-length = 99
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-  | tests/assets
-)/
-'''
 
 [tool.ruff]
 line-length = 99
+src = ["typenames", "tests"]
+
+[tool.ruff.lint]
 select = [
   "E", # Pyflakes
   "F", # Pycodestyle
   "I", # isort
 ]
-src = ["typenames.py", "tests.py"]
 unfixable = ["F"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["typenames"]
 force-sort-within-sections = true
 
 [tool.mypy]
-ignore_missing_imports = true
+files = ["typenames", "tests/typechecks.py"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests.py"]
+testpaths = ["tests"]
 
 [tool.coverage.run]
-source = ["typenames.py"]
+source = ["typenames"]

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -50,10 +50,10 @@ cases = [
     (typing.List[int], "List[int]"),
     (typing.Tuple[str, int], "Tuple[str, int]"),
     (typing.Optional[int], "Optional[int]"),
-    (MyClass, "tests.MyClass"),
-    (OuterClass.InnerClass, "tests.OuterClass.InnerClass"),
-    (typing.List[MyClass], "List[tests.MyClass]"),
-    (typing.Optional[typing.List[MyClass]], "Optional[List[tests.MyClass]]"),
+    (MyClass, "test_typenames.MyClass"),
+    (OuterClass.InnerClass, "test_typenames.OuterClass.InnerClass"),
+    (typing.List[MyClass], "List[test_typenames.MyClass]"),
+    (typing.Optional[typing.List[MyClass]], "Optional[List[test_typenames.MyClass]]"),
     (typing.Union[float, int], "Union[float, int]"),
     (typing.Dict[str, int], "Dict[str, int]"),
     (typing.Any, "Any"),
@@ -61,8 +61,8 @@ cases = [
     (typing.Callable[..., str], "Callable[..., str]"),
     (typing.Callable[[int], str], "Callable[[int], str]"),
     (typing.Callable[[int, float], str], "Callable[[int, float], str]"),
-    (MyGeneric[int], "tests.MyGeneric[int]"),
-    (MyEnum, "tests.MyEnum"),
+    (MyGeneric[int], "test_typenames.MyGeneric[int]"),
+    (MyEnum, "test_typenames.MyEnum"),
     (typing.List["int"], "List[int]"),
     (typing.List["typing.Any"], "List[Any]"),
     (typing.List["enum.Enum"], "List[enum.Enum]"),
@@ -71,7 +71,7 @@ cases = [
     # Python 3.8 adds typing.Literal, typing.Final, typing.TypedDict
     (typing.Literal["s", 0, MyEnum.MEMBER1], "Literal['s', 0, MyEnum.MEMBER1]"),
     (typing.Final[int], "Final[int]"),
-    (MyTypedDict, "tests.MyTypedDict"),
+    (MyTypedDict, "test_typenames.MyTypedDict"),
 ]
 
 
@@ -126,23 +126,24 @@ def test_remove_modules():
         __module__ = "other_module"
 
     # Class defined in a function scope
-    class FnScopeClass: ...
+    class FnScopeClass:
+        ...
 
     # Default removal
     assert typenames(typing.Any) == "Any"
-    assert typenames(MyClass) == "tests.MyClass"
+    assert typenames(MyClass) == "test_typenames.MyClass"
     assert typenames(OtherModuleClass) == "other_module.OtherModuleClass"
-    assert typenames(FnScopeClass) == "tests.test_remove_modules.<locals>.FnScopeClass"
+    assert typenames(FnScopeClass) == "test_typenames.test_remove_modules.<locals>.FnScopeClass"
 
     # Override
-    config = TypenamesConfig(remove_modules=["tests"])
+    config = TypenamesConfig(remove_modules=["test_typenames"])
     assert typenames(typing.Any, config=config) == "typing.Any"
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
     assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
 
     # Add to defaults
-    config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["tests"])
+    config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["test_typenames"])
     assert typenames(typing.Any, config=config) == "Any"
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
@@ -278,7 +279,9 @@ is_union_special_form_cases = [
 
 
 @pytest.mark.parametrize(
-    "case", is_union_special_form_cases, ids=[str(c[0]) for c in is_union_special_form_cases]
+    "case",
+    is_union_special_form_cases,
+    ids=[str(c[0]) for c in is_union_special_form_cases],
 )
 def test_is_union_special_form(case):
     """Test that is_union_special_form correctly identifies if using typing.Union."""
@@ -286,7 +289,9 @@ def test_is_union_special_form(case):
 
 
 @pytest.mark.parametrize(
-    "case", is_union_special_form_cases, ids=[str(c[0]) for c in is_union_special_form_cases]
+    "case",
+    is_union_special_form_cases,
+    ids=[str(c[0]) for c in is_union_special_form_cases],
 )
 def test_is_union_or_operator_for_typing_alias_cases(case):
     """Test that is_union_or_operator correctly returns False for all typing.Union test cases."""
@@ -305,14 +310,18 @@ if sys.version_info >= (3, 10):
     ]
 
     @pytest.mark.parametrize(
-        "case", is_union_or_operator_cases, ids=[str(c[0]) for c in is_union_or_operator_cases]
+        "case",
+        is_union_or_operator_cases,
+        ids=[str(c[0]) for c in is_union_or_operator_cases],
     )
     def test_is_union_or_operator(case):
         """Test that is_union_or_operator correctly identifies cases using | operator."""
         assert is_union_or_operator(case[0]) == case[1]
 
     @pytest.mark.parametrize(
-        "case", is_union_or_operator_cases, ids=[str(c[0]) for c in is_union_or_operator_cases]
+        "case",
+        is_union_or_operator_cases,
+        ids=[str(c[0]) for c in is_union_or_operator_cases],
     )
     def test_is_union_special_form_for_or_operator_cases(case):
         """Test that is_union_special_form correctly returns False for all | operator cases."""

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -126,8 +126,7 @@ def test_remove_modules():
         __module__ = "other_module"
 
     # Class defined in a function scope
-    class FnScopeClass:
-        ...
+    class FnScopeClass: ...
 
     # Default removal
     assert typenames(typing.Any) == "Any"

--- a/tests/typechecks.py
+++ b/tests/typechecks.py
@@ -1,0 +1,27 @@
+import typing
+
+from typenames import parse_type_tree, typenames
+
+typenames(int)
+# Unions
+typenames(str | int)
+typenames(typing.Union[str, int])
+typenames(typing.Optional[str])
+# Generics
+typenames(dict[str, int])
+typenames(typing.Dict[str, int])
+# Other special forms
+typenames(typing.Any)
+typenames(typing.Literal["foo"])
+
+parse_type_tree(int)
+# Unions
+parse_type_tree(str | int)
+parse_type_tree(typing.Union[str, int])
+parse_type_tree(typing.Optional[str])
+# Generics
+parse_type_tree(dict[str, int])
+parse_type_tree(typing.Dict[str, int])
+# Other special forms
+parse_type_tree(typing.Any)
+parse_type_tree(typing.Literal["foo"])

--- a/typenames/__init__.py
+++ b/typenames/__init__.py
@@ -76,9 +76,7 @@ class TypenamesConfig:
 
     union_syntax: UnionSyntax = UnionSyntax.AS_GIVEN
     optional_syntax: OptionalSyntax = OptionalSyntax.AS_GIVEN
-    standard_collection_syntax: StandardCollectionSyntax = (
-        StandardCollectionSyntax.AS_GIVEN
-    )
+    standard_collection_syntax: StandardCollectionSyntax = StandardCollectionSyntax.AS_GIVEN
     remove_modules: List[Union[str, re.Pattern]] = dataclasses.field(
         default_factory=lambda: list(DEFAULT_REMOVE_MODULES)
     )
@@ -86,9 +84,7 @@ class TypenamesConfig:
     def __post_init__(self):
         self.union_syntax = UnionSyntax(self.union_syntax)
         self.optional_syntax = OptionalSyntax(self.optional_syntax)
-        self.standard_collection_syntax = StandardCollectionSyntax(
-            self.standard_collection_syntax
-        )
+        self.standard_collection_syntax = StandardCollectionSyntax(self.standard_collection_syntax)
 
     @property
     def remove_modules_patterns(self) -> typing.Iterator[re.Pattern]:
@@ -218,10 +214,7 @@ class GenericNode(BaseNode):
         elif is_union_or_operator(self.tp):
             is_optional = any(a.is_none_type for a in arg_nodes)
             # Case: ... | None (optional) and configured to use typing.Optional
-            if (
-                is_optional
-                and self.config.optional_syntax == OptionalSyntax.OPTIONAL_SPECIAL_FORM
-            ):
+            if is_optional and self.config.optional_syntax == OptionalSyntax.OPTIONAL_SPECIAL_FORM:
                 origin_module_prefix = "typing."
                 origin_name = "Optional"
                 arg_nodes = [a for a in arg_nodes if a.tp is not type(None)]
@@ -237,10 +230,7 @@ class GenericNode(BaseNode):
                         )
                     ]
             # Case: ... | None (optional) and configured to use typing.Union
-            elif (
-                is_optional
-                and self.config.optional_syntax == OptionalSyntax.UNION_SPECIAL_FORM
-            ):
+            elif is_optional and self.config.optional_syntax == OptionalSyntax.UNION_SPECIAL_FORM:
                 origin_module_prefix = "typing."
                 origin_name = "Union"
             # Case: regular union
@@ -252,13 +242,8 @@ class GenericNode(BaseNode):
                     return " | ".join(str(a) for a in arg_nodes)
         # Case: Standard collection class alias
         elif is_standard_collection_type_alias(self.tp):
-            if (
-                self.config.standard_collection_syntax
-                == StandardCollectionSyntax.TYPING_MODULE
-            ):
-                typing_alias = STANDARD_COLLECTION_TO_TYPING_ALIAS_MAPPING[
-                    get_origin(self.tp)
-                ]
+            if self.config.standard_collection_syntax == StandardCollectionSyntax.TYPING_MODULE:
+                typing_alias = STANDARD_COLLECTION_TO_TYPING_ALIAS_MAPPING[get_origin(self.tp)]
                 origin_module_prefix = "typing."
                 origin_name = f"{typing_alias._name}"  # type: ignore
             else:
@@ -266,10 +251,7 @@ class GenericNode(BaseNode):
                 origin_name = self.origin.__qualname__  # type: ignore[union-attr]
         # Case: Typing module collection alias
         elif is_typing_module_collection_alias(self.tp):
-            if (
-                self.config.standard_collection_syntax
-                == StandardCollectionSyntax.STANDARD_CLASS
-            ):
+            if self.config.standard_collection_syntax == StandardCollectionSyntax.STANDARD_CLASS:
                 origin_module_prefix = self.origin.__module__ + "."
                 origin_name = self.origin.__qualname__  # type: ignore[union-attr]
             else:
@@ -366,9 +348,7 @@ def parse_type_tree(
         )
     elif isinstance(tp, list):
         # This is the parameter list for Callable
-        node = ParamsListNode(
-            tp=tp, arg_nodes=[parse_type_tree(a) for a in tp], config=config
-        )
+        node = ParamsListNode(tp=tp, arg_nodes=[parse_type_tree(a) for a in tp], config=config)
     elif isinstance(tp, (int, bytes, str, Enum, bool)) or tp is None:
         node = LiteralNode(tp=tp, config=config)
     else:
@@ -376,9 +356,7 @@ def parse_type_tree(
     return node
 
 
-def typenames(
-    tp: _TypeForm, config: Optional[TypenamesConfig] = None, **kwargs: Any
-) -> str:
+def typenames(tp: _TypeForm, config: Optional[TypenamesConfig] = None, **kwargs: Any) -> str:
     """Render a string representation of a type annotation.
 
     Args:
@@ -452,9 +430,7 @@ STANDARD_COLLECTION_TO_TYPING_ALIAS_MAPPING = {
 """Mapping from standard collection types that support use as a generic type starting in
 Python 3.9 (PEP 585) to their associated typing module generic alias."""
 
-STANDARD_COLLECTION_CLASSES = frozenset(
-    STANDARD_COLLECTION_TO_TYPING_ALIAS_MAPPING.keys()
-)
+STANDARD_COLLECTION_CLASSES = frozenset(STANDARD_COLLECTION_TO_TYPING_ALIAS_MAPPING.keys())
 """Frozenset of standard collection classes that support use as a generic type starting in
 Python 3.9 (PEP 585)."""
 


### PR DESCRIPTION
- Fixes type signatures to use a `_TypeForm` type variable. This unfortunately has to union with `object` to reflect the type of special forms. We can dream of someday replacing this with `TypeForm` a la https://github.com/python/mypy/issues/9773
- Adds a `py.typed` PEP 561 marker file
- Adds a `tests/typechecks.py` that we run through mypy to test typechecking more explicitly
- Reorganizes stuff into directories
- Switch from black to ruff formatting