### PR TITLE
Fix config propagation in Callable parameter lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added explicit handling of [PEP 695](https://peps.python.org/pep-0695/) type aliases (`type X = ...`, `typing.TypeAliasType`). Rendering was already correct by accident but is now deliberate and tested. ([PR #24](https://github.com/drivendataorg/typenames/pull/24), [Issue #19](https://github.com/drivendataorg/typenames/issues/19))
 - Added `is_type_alias_type` predicate function. ([PR #24](https://github.com/drivendataorg/typenames/pull/24), [Issue #19](https://github.com/drivendataorg/typenames/issues/19))
 - Fixed incorrect `__version__` value. ([PR #20](https://github.com/drivendataorg/typenames/pull/20), [Issue #18](https://github.com/drivendataorg/typenames/issues/18))
+- Fixed missing config propagation for the parameters of a `Callable`. ([PR #23](https://github.com/drivendataorg/typenames/pull/23) thanks to [@nightcityblade](https://github.com/nightcityblade), [Issue #21](https://github.com/drivendataorg/typenames/issues/21))
 
 ## v2.1.0 (2025-09-15)
 

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -174,6 +174,10 @@ def test_remove_modules():
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
     assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
+    assert (
+        typenames(typing.Callable[[int], int], remove_modules=[])
+        == "collections.abc.Callable[[builtins.int], builtins.int]"
+    )
 
     # Add to defaults
     config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["tests.test_typenames"])
@@ -291,6 +295,13 @@ def test_standard_collection_syntax_typing_module():
     generic aliases."""
     assert typenames(typing.List[int], standard_collection_syntax="typing_module") == "List[int]"
     assert typenames(list[int], standard_collection_syntax="typing_module") == "List[int]"
+    assert (
+        typenames(
+            typing.Callable[[typing.List[int]], int],
+            standard_collection_syntax="typing_module",
+        )
+        == "Callable[[List[int]], int]"
+    )
 
 
 def test_annotated_include_extras():
@@ -302,6 +313,10 @@ def test_annotated_include_extras():
 
     obj = object()
     assert typenames(Annotated[str, obj], include_extras=True) == f"Annotated[str, {obj}]"
+    assert (
+        typenames(typing.Callable[[Annotated[int, "meta"]], int], include_extras=True)
+        == "Callable[[Annotated[int, 'meta']], int]"
+    )
 
 
 def test_node_repr():

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -196,15 +196,15 @@ def test_remove_modules():
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
     assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
+    assert (
+        typenames(typing.Callable[[MyClass], OtherModuleClass], config=config)
+        == "collections.abc.Callable[[MyClass], other_module.OtherModuleClass]"
+    )
     if sys.version_info >= (3, 12):
         # The override above targets tests.test_typenames, not the alias's own module, so a
         # dedicated config is needed to actually strip the alias's module prefix.
         alias_config = TypenamesConfig(remove_modules=["tests.type_statement_fixtures"])
         assert typenames(type_statement_fixtures.Simple, config=alias_config) == "Simple"
-    assert (
-        typenames(typing.Callable[[int], int], remove_modules=[])
-        == "collections.abc.Callable[[builtins.int], builtins.int]"
-    )
 
     # Add to defaults
     config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["tests.test_typenames"])

--- a/typenames/__init__.py
+++ b/typenames/__init__.py
@@ -356,7 +356,11 @@ def parse_type_tree(
         )
     elif isinstance(tp, list):
         # This is the parameter list for Callable
-        node = ParamsListNode(tp=tp, arg_nodes=[parse_type_tree(a) for a in tp], config=config)
+        node = ParamsListNode(
+            tp=tp,
+            arg_nodes=[parse_type_tree(a, config=config) for a in tp],
+            config=config,
+        )
     elif isinstance(tp, (int, bytes, str, Enum, bool)) or tp is None:
         node = LiteralNode(tp=tp, config=config)
     else:


### PR DESCRIPTION
Fixes #21.

`parse_type_tree` now passes the active `TypenamesConfig` into children of a `Callable` parameter list, matching how all other nested type nodes are parsed. This keeps options such as `remove_modules`, `standard_collection_syntax`, and `include_extras` consistent between parameter and return types.

Regression coverage verifies all three configuration paths inside `Callable` parameters.

Tests:

- `uv run --python 3.13 --isolated --no-editable --no-dev --group tests --reinstall python -I -m pytest tests/test_typenames.py` — 119 passed
- `uv run ruff format --check`
- `uv run ruff check typenames/__init__.py tests/test_typenames.py`
- `uv run --python 3.13 --no-dev --group typecheck --isolated mypy typenames tests/typechecks.py --install-types --non-interactive`
