### PR TITLE
Explicitly handle PEP 695 type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v2.2.0 (Unreleased)
 
-- Added explicit handling of [PEP 695](https://peps.python.org/pep-0695/) type aliases (`type X = ...`, `typing.TypeAliasType`). Rendering was already correct by accident (via a `repr()` fallback); it is now deliberate and tested. ([Issue #19](https://github.com/drivendataorg/typenames/issues/19))
-- Added `is_type_alias_type` predicate function. ([Issue #19](https://github.com/drivendataorg/typenames/issues/19))
-- Fixed incorrect `__version__` value.
+- Added explicit handling of [PEP 695](https://peps.python.org/pep-0695/) type aliases (`type X = ...`, `typing.TypeAliasType`). Rendering was already correct by accident but is now deliberate and tested. ([PR #24](https://github.com/drivendataorg/typenames/pull/24), [Issue #19](https://github.com/drivendataorg/typenames/issues/19))
+- Added `is_type_alias_type` predicate function. ([PR #24](https://github.com/drivendataorg/typenames/pull/24), [Issue #19](https://github.com/drivendataorg/typenames/issues/19))
+- Fixed incorrect `__version__` value. ([PR #20](https://github.com/drivendataorg/typenames/pull/20), [Issue #18](https://github.com/drivendataorg/typenames/issues/18))
 
 ## v2.1.0 (2025-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## v2.1.1 (Unreleased)
+## v2.2.0 (Unreleased)
 
+- Added explicit handling of [PEP 695](https://peps.python.org/pep-0695/) type aliases (`type X = ...`, `typing.TypeAliasType`). Rendering was already correct by accident (via a `repr()` fallback); it is now deliberate and tested. ([Issue #19](https://github.com/drivendataorg/typenames/issues/19))
+- Added `is_type_alias_type` predicate function. ([Issue #19](https://github.com/drivendataorg/typenames/issues/19))
 - Fixed incorrect `__version__` value.
 
 ## v2.1.0 (2025-09-15)

--- a/README.md
+++ b/README.md
@@ -211,6 +211,22 @@ typenames(Annotated[int, "some metadata"], include_extras=True)
 #> "Annotated[int, 'some metadata']"
 ```
 
+## Type Aliases (PEP 695)
+
+typenames recognizes [PEP 695](https://peps.python.org/pep-0695/) type aliases, i.e., ones defined with the `type` statement (Python 3.12+) or constructed directly with `typing.TypeAliasType` / `typing_extensions.TypeAliasType`. An alias renders as its name, with the same `remove_modules` handling applied to its module prefix as any other type. typenames does not expand aliases to show what they point to.
+
+```python
+type MyAlias = list[int]
+
+typenames(MyAlias)
+#> 'MyAlias'
+typenames(list[MyAlias])
+#> 'list[MyAlias]'
+```
+
+> [!NOTE]
+> A union containing an alias to `None` does **not** collapse to `Optional[...]`, even with `optional_syntax="optional_special_form"`.
+
 ---
 
 <sup>Reproducible examples created by <a href="https://github.com/jayqi/reprexlite">reprexlite</a>.</sup>

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ typenames(Annotated[int, "some metadata"], include_extras=True)
 typenames recognizes [PEP 695](https://peps.python.org/pep-0695/) type aliases, i.e., ones defined with the `type` statement (Python 3.12+) or constructed directly with `typing.TypeAliasType` / `typing_extensions.TypeAliasType`. An alias renders as its name, with the same `remove_modules` handling applied to its module prefix as any other type. typenames does not expand aliases to show what they point to.
 
 ```python
+from typenames import typenames
+
 type MyAlias = list[int]
 
 typenames(MyAlias)
@@ -223,6 +225,9 @@ typenames(MyAlias)
 typenames(list[MyAlias])
 #> 'list[MyAlias]'
 ```
+
+> [!NOTE]
+> The `type` statement is new in Python 3.12. On earlier versions, an equivalent alias can be constructed directly with `typing_extensions.TypeAliasType`.
 
 > [!NOTE]
 > A union containing an alias to `None` does **not** collapse to `Optional[...]`, even with `optional_syntax="optional_special_form"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typenames"
-version = "2.1.1"
+version = "2.2.0"
 description = "String representations of type annotations."
 readme = "README.md"
 authors = [{ name = "Jay Qi", email = "jayqi.opensource@gmail.com" }]
@@ -54,6 +54,7 @@ tests = [
   "pytest",
   "coverage",
   "pytest-cov",
+  "typing_extensions",
 ]
 docs = [
   "markdown-callouts",
@@ -74,6 +75,9 @@ inspect-types = [
 [tool.ruff]
 line-length = 99
 src = ["typenames", "tests"]
+
+[tool.ruff.per-file-target-version]
+"tests/type_statement_fixtures.py" = "py312"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 tests = [
   "pytest>=6",
-  "typing_extensions",
+  "typing_extensions>=4.6.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ classifiers = [
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-tests = ["pytest>=6"]
+tests = [
+  "pytest>=6",
+  "typing_extensions",
+]
 
 [project.urls]
 "Homepage" = "https://typenames.drivendata.org/"
@@ -51,10 +54,9 @@ typecheck = [
   "mypy",
 ]
 tests = [
-  "pytest",
+  "typenames[tests]",
   "coverage",
   "pytest-cov",
-  "typing_extensions",
 ]
 docs = [
   "markdown-callouts",

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -12,12 +12,16 @@ from typenames import (
     TypenamesConfig,
     is_annotated_special_form,
     is_standard_collection_type_alias,
+    is_type_alias_type,
     is_typing_module_collection_alias,
     is_union_or_operator,
     is_union_special_form,
     parse_type_tree,
     typenames,
 )
+
+if sys.version_info >= (3, 12):
+    from tests import type_statement_fixtures
 
 T = typing.TypeVar("T")
 
@@ -134,6 +138,22 @@ if sys.version_info >= (3, 11):
             (typing.LiteralString, "LiteralString"),
             (typing.Never, "Never"),
             (typing.Self, "Self"),
+        ]
+    )
+
+if sys.version_info >= (3, 12):
+    # Python 3.12 adds the `type` statement (PEP 695, TypeAliasType)
+    cases.extend(
+        [
+            (type_statement_fixtures.Simple, "tests.type_statement_fixtures.Simple"),
+            (type_statement_fixtures.Gen, "tests.type_statement_fixtures.Gen"),
+            (type_statement_fixtures.Gen[int], "tests.type_statement_fixtures.Gen[int]"),
+            (
+                list[type_statement_fixtures.Simple],
+                "list[tests.type_statement_fixtures.Simple]",
+            ),
+            # Recursive alias renders fine because rendering never reads __value__
+            (type_statement_fixtures.JSON, "tests.type_statement_fixtures.JSON"),
         ]
     )
 
@@ -473,3 +493,57 @@ def test_nested_collection_types_nested_both():
 def test_annotated():
     assert is_annotated_special_form(Annotated[str, "some metadata"]) is True
     assert is_annotated_special_form(Annotated[str, object()]) is True
+
+
+def test_type_alias_type_typing_extensions_constructor():
+    """Regression test that an alias constructed directly via typing_extensions.TypeAliasType
+    is recognized and rendered by name, on every supported Python version. This is distinct
+    from `type_statement_fixtures`, which requires Python 3.12+ for the `type` statement:
+    typing_extensions.TypeAliasType remains a *different* class from typing.TypeAliasType even
+    on 3.12+ (it is not re-exported), so a library that constructs aliases this way to support
+    multiple Python versions uniformly must still be recognized there."""
+    import typing_extensions
+
+    alias = typing_extensions.TypeAliasType("ConstructedAlias", list[int])
+    assert is_type_alias_type(alias) is True
+    assert typenames(alias) == "tests.test_typenames.ConstructedAlias"
+
+
+if sys.version_info >= (3, 12):
+    is_type_alias_type_cases = [
+        (type_statement_fixtures.Simple, True),
+        (type_statement_fixtures.Gen, True),
+        (type_statement_fixtures.Gen[int], False),
+        (int, False),
+        (typing.List[int], False),
+        (list[int], False),
+        (MyClass, False),
+    ]
+
+    @pytest.mark.parametrize(
+        "case",
+        is_type_alias_type_cases,
+        ids=[str(c[0]) for c in is_type_alias_type_cases],
+    )
+    def test_is_type_alias_type(case):
+        assert is_type_alias_type(case[0]) == case[1]
+
+    def test_type_alias_to_none_does_not_fold_to_optional():
+        """A union with an alias to None should not collapse to Optional, since that would
+        erase the alias name from the rendered output. See issue #19."""
+        if sys.version_info < (3, 14):
+            assert (
+                typenames(
+                    typing.Union[int, type_statement_fixtures.NoneAlias],
+                    optional_syntax="optional_special_form",
+                )
+                == "Union[int, tests.type_statement_fixtures.NoneAlias]"
+            )
+        else:
+            assert (
+                typenames(
+                    typing.Union[int, type_statement_fixtures.NoneAlias],
+                    optional_syntax="optional_special_form",
+                )
+                == "int | tests.type_statement_fixtures.NoneAlias"
+            )

--- a/tests/test_typenames.py
+++ b/tests/test_typenames.py
@@ -187,6 +187,8 @@ def test_remove_modules():
     assert (
         typenames(FnScopeClass) == "tests.test_typenames.test_remove_modules.<locals>.FnScopeClass"
     )
+    if sys.version_info >= (3, 12):
+        assert typenames(type_statement_fixtures.Simple) == "tests.type_statement_fixtures.Simple"
 
     # Override
     config = TypenamesConfig(remove_modules=["tests.test_typenames"])
@@ -194,6 +196,11 @@ def test_remove_modules():
     assert typenames(MyClass, config=config) == "MyClass"
     assert typenames(OtherModuleClass, config=config) == "other_module.OtherModuleClass"
     assert typenames(FnScopeClass, config=config) == "test_remove_modules.<locals>.FnScopeClass"
+    if sys.version_info >= (3, 12):
+        # The override above targets tests.test_typenames, not the alias's own module, so a
+        # dedicated config is needed to actually strip the alias's module prefix.
+        alias_config = TypenamesConfig(remove_modules=["tests.type_statement_fixtures"])
+        assert typenames(type_statement_fixtures.Simple, config=alias_config) == "Simple"
 
     # Add to defaults
     config = TypenamesConfig(remove_modules=DEFAULT_REMOVE_MODULES + ["tests.test_typenames"])
@@ -211,6 +218,8 @@ def test_remove_modules():
     assert typenames(FnScopeClass, config=config) == "FnScopeClass"
 
     assert typenames(collections.Counter[str], config=config) == "Counter[str]"
+    if sys.version_info >= (3, 12):
+        assert typenames(type_statement_fixtures.Simple, config=config) == "Simple"
     assert typenames(collections.abc.Sequence[str], config=config) == "Sequence[str]"
 
 

--- a/tests/type_statement_fixtures.py
+++ b/tests/type_statement_fixtures.py
@@ -1,0 +1,24 @@
+"""PEP 695 `type` statement fixtures for TypeAliasType tests.
+
+This module exists separately from test_typenames.py because `type X = ...` is grammar,
+not a runtime construct: `if sys.version_info >= (3, 12): type X = ...` is a SyntaxError
+at compile time on Python < 3.12, so the containing module would never import. This
+module is only imported by tests that are themselves guarded on Python >= 3.12.
+
+It is also exempted from ruff's inferred `target-version` via
+`[tool.ruff.per-file-target-version]` in pyproject.toml, since ruff would otherwise parse
+it as Python 3.9 (from `requires-python`) and reject the `type` statement as invalid
+syntax.
+"""
+
+import typing
+
+
+class Inner:
+    pass
+
+
+type Simple = list[Inner]
+type Gen[T] = list[T]
+type NoneAlias = None
+type JSON = typing.Union[str, int, list[JSON]]

--- a/typenames/__init__.py
+++ b/typenames/__init__.py
@@ -25,6 +25,24 @@ else:
     _TypeForm = typing.TypeVar("_TypeForm", bound=typing.Union[type, object])
 
 
+# TypeAliasType for PEP 695 type aliases
+_TYPE_ALIAS_TYPES: tuple[type, ...] = ()
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+
+    _TYPE_ALIAS_TYPES += (TypeAliasType,)
+try:
+    # typing_extensions.TypeAliasType is a distinct class from typing.TypeAliasType even on
+    # Python 3.12+ (it is not simply re-exported), so both are checked when typing_extensions
+    # is installed: a library targeting multiple Python versions may construct aliases via
+    # typing_extensions.TypeAliasType directly rather than the `type` statement.
+    from typing_extensions import TypeAliasType as _TypingExtensionsTypeAliasType
+
+    _TYPE_ALIAS_TYPES += (_TypingExtensionsTypeAliasType,)
+except ImportError:
+    pass
+
+
 class UnionSyntax(str, Enum):
     """Enum for union syntax options. See "Union Syntax" section of README for documentation."""
 
@@ -155,6 +173,8 @@ class TypeNode(BaseNode):
                 # ForwardRef object will have __module__ of typing (<3.14) or annotationlib (3.14+)
                 # This is not the module of the actual type, so we blank it out
                 module_prefix = ""
+        elif is_type_alias_type(self.tp):
+            type_name = self.tp.__name__
         else:
             type_name = getattr(self.tp, "__qualname__", repr(self.tp))
         for pattern in self.config.remove_modules_patterns:
@@ -191,7 +211,7 @@ class GenericNode(BaseNode):
                 else:
                     origin_module_prefix = "typing."
                     origin_name = "Optional"
-                    arg_nodes = [a for a in arg_nodes if a.tp is not type(None)]
+                    arg_nodes = [a for a in arg_nodes if not a.is_none_type]
                     if len(arg_nodes) > 1:
                         # typing.Optional is only valid for a single parameter,
                         # need to use a union inside
@@ -218,7 +238,7 @@ class GenericNode(BaseNode):
             if is_optional and self.config.optional_syntax == OptionalSyntax.OPTIONAL_SPECIAL_FORM:
                 origin_module_prefix = "typing."
                 origin_name = "Optional"
-                arg_nodes = [a for a in arg_nodes if a.tp is not type(None)]
+                arg_nodes = [a for a in arg_nodes if not a.is_none_type]
                 if len(arg_nodes) > 1:
                     # typing.Optional is only valid for a single parameter,
                     # need to use a union inside
@@ -471,3 +491,11 @@ def is_typing_module_collection_alias(tp: type) -> bool:
 def is_annotated_special_form(tp: type) -> bool:
     """Check if type annotation is the typing.Annotated special form."""
     return get_origin(tp) is Annotated
+
+
+def is_type_alias_type(tp: Any) -> bool:
+    """Check if type annotation is a PEP 695 type alias (typing.TypeAliasType), e.g., one
+    created with the `type` statement. Does not match a subscripted generic type alias, e.g.,
+    `Gen[int]` for `type Gen[T] = list[T]`, since that is a types.GenericAlias whose origin is
+    the TypeAliasType."""
+    return isinstance(tp, _TYPE_ALIAS_TYPES)

--- a/typenames/__init__.py
+++ b/typenames/__init__.py
@@ -32,14 +32,14 @@ if sys.version_info >= (3, 12):
 
     _TYPE_ALIAS_TYPES += (TypeAliasType,)
 try:
-    # typing_extensions.TypeAliasType is a distinct class from typing.TypeAliasType even on
-    # Python 3.12+ (it is not simply re-exported), so both are checked when typing_extensions
+    # typing_extensions.TypeAliasType is a distinct class from typing.TypeAliasType on Python
+    # 3.12 and 3.13 (not simply re-exported there), so both are checked when typing_extensions
     # is installed: a library targeting multiple Python versions may construct aliases via
     # typing_extensions.TypeAliasType directly rather than the `type` statement.
     from typing_extensions import TypeAliasType as _TypingExtensionsTypeAliasType
 
     _TYPE_ALIAS_TYPES += (_TypingExtensionsTypeAliasType,)
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 
@@ -493,7 +493,7 @@ def is_annotated_special_form(tp: type) -> bool:
     return get_origin(tp) is Annotated
 
 
-def is_type_alias_type(tp: Any) -> bool:
+def is_type_alias_type(tp: _TypeForm) -> bool:
     """Check if type annotation is a PEP 695 type alias (typing.TypeAliasType), e.g., one
     created with the `type` statement. Does not match a subscripted generic type alias, e.g.,
     `Gen[int]` for `type Gen[T] = list[T]`, since that is a types.GenericAlias whose origin is

--- a/uv.lock
+++ b/uv.lock
@@ -2161,6 +2161,7 @@ source = { editable = "." }
 [package.optional-dependencies]
 tests = [
     { name = "pytest" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -2197,16 +2198,18 @@ lint = [
 ]
 tests = [
     { name = "coverage" },
-    { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "typing-extensions" },
+    { name = "typenames", extra = ["tests"] },
 ]
 typecheck = [
     { name = "mypy" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'tests'", specifier = ">=6" }]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'tests'", specifier = ">=6" },
+    { name = "typing-extensions", marker = "extra == 'tests'" },
+]
 provides-extras = ["tests"]
 
 [package.metadata.requires-dev]
@@ -2239,9 +2242,8 @@ inspect-types = [
 lint = [{ name = "ruff" }]
 tests = [
     { name = "coverage" },
-    { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "typing-extensions" },
+    { name = "typenames", extras = ["tests"] },
 ]
 typecheck = [{ name = "mypy" }]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2208,7 +2208,7 @@ typecheck = [
 [package.metadata]
 requires-dist = [
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=6" },
-    { name = "typing-extensions", marker = "extra == 'tests'" },
+    { name = "typing-extensions", marker = "extra == 'tests'", specifier = ">=4.6.0" },
 ]
 provides-extras = ["tests"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2155,7 +2155,7 @@ wheels = [
 
 [[package]]
 name = "typenames"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -2199,6 +2199,7 @@ tests = [
     { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "typing-extensions" },
 ]
 typecheck = [
     { name = "mypy" },
@@ -2240,6 +2241,7 @@ tests = [
     { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "typing-extensions" },
 ]
 typecheck = [{ name = "mypy" }]
 


### PR DESCRIPTION
Add explicit handling of PEP 695 type aliases and `is_type_alias_type` predicate function.